### PR TITLE
Upgrade to v2.6.0

### DIFF
--- a/MotelPos/MotelPos.csproj
+++ b/MotelPos/MotelPos.csproj
@@ -41,7 +41,8 @@
       <HintPath>..\packages\RestSharpSigned.105.2.3\lib\net45\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="SPIClient, Version=2.5.0.136, Culture=neutral, PublicKeyToken=edf39156ce36eff9, processorArchitecture=MSIL">
-      <HintPath>..\packages\SPIClient.2.5.0\lib\net45\SPIClient.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\spi-client-windows\feature-v2.6.0\SPIClient\bin\Debug\SPIClient.dll</HintPath>
     </Reference>
     <Reference Include="SuperSocket.ClientEngine, Version=0.10.0.0, Culture=neutral, PublicKeyToken=ee9af13f57f00acc, processorArchitecture=MSIL">
       <HintPath>..\packages\SuperSocket.ClientEngine.Core.0.10.0\lib\net45\SuperSocket.ClientEngine.dll</HintPath>

--- a/MotelPos/Program.cs
+++ b/MotelPos/Program.cs
@@ -34,7 +34,7 @@ namespace MotelPos
             LoadPersistedState();
 
             _spi = new Spi(_posId, _serialNumber, _eftposAddress, _spiSecrets); // It is ok to not have the secrets yet to start with.
-            _spi.SetPosInfo("assembly", "2.5.0");
+            _spi.SetPosInfo("assembly", "2.6.0");
             _spi.StatusChanged += OnSpiStatusChanged;
             _spi.PairingFlowStateChanged += OnPairingFlowStateChanged;
             _spi.SecretsChanged += OnSecretsChanged;

--- a/RamenPos/ActionsForm.cs
+++ b/RamenPos/ActionsForm.cs
@@ -46,7 +46,7 @@ namespace RamenPos
                 case ButtonCaption.OKUnpaired:
                     SpiClient.AckFlowEndedAndBackToIdle();
                     MainForm.btnMain.Text = ButtonCaption.Pair;
-                    TransactionForm.lblStatus.BackColor = Color.Red;                    
+                    TransactionForm.lblStatus.BackColor = Color.Red;
                     MainForm.grpSecrets.Enabled = true;
                     MainForm.grpAutoAddressResolution.Enabled = true;
                     MainForm.grpSettings.Enabled = true;

--- a/RamenPos/ComponentLabels.cs
+++ b/RamenPos/ComponentLabels.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace RamenPos
+﻿namespace RamenPos
 {
     public static class ButtonCaption
     {

--- a/RamenPos/MainForm.Designer.cs
+++ b/RamenPos/MainForm.Designer.cs
@@ -36,7 +36,7 @@
             this.txtSerialNumber = new System.Windows.Forms.TextBox();
             this.lblSerialNumber = new System.Windows.Forms.Label();
             this.lblEftposAddress = new System.Windows.Forms.Label();
-            this.chkAutoAddress = new System.Windows.Forms.CheckBox();
+            this.cboxAutoAddress = new System.Windows.Forms.CheckBox();
             this.txtAddress = new System.Windows.Forms.TextBox();
             this.btnMain = new System.Windows.Forms.Button();
             this.lblDescription = new System.Windows.Forms.Label();
@@ -62,10 +62,9 @@
             // pbRamenPos
             // 
             this.pbRamenPos.Image = global::RamenPos.Properties.Resources._450191;
-            this.pbRamenPos.Location = new System.Drawing.Point(60, 119);
-            this.pbRamenPos.Margin = new System.Windows.Forms.Padding(6);
+            this.pbRamenPos.Location = new System.Drawing.Point(30, 62);
             this.pbRamenPos.Name = "pbRamenPos";
-            this.pbRamenPos.Size = new System.Drawing.Size(820, 756);
+            this.pbRamenPos.Size = new System.Drawing.Size(410, 393);
             this.pbRamenPos.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.pbRamenPos.TabIndex = 0;
             this.pbRamenPos.TabStop = false;
@@ -74,41 +73,37 @@
             // 
             this.lblPosId.AutoSize = true;
             this.lblPosId.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblPosId.Location = new System.Drawing.Point(12, 31);
-            this.lblPosId.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblPosId.Location = new System.Drawing.Point(6, 16);
             this.lblPosId.Name = "lblPosId";
-            this.lblPosId.Size = new System.Drawing.Size(100, 31);
+            this.lblPosId.Size = new System.Drawing.Size(52, 16);
             this.lblPosId.TabIndex = 1;
             this.lblPosId.Text = "POS ID";
             // 
             // txtPosId
             // 
             this.txtPosId.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtPosId.Location = new System.Drawing.Point(12, 73);
-            this.txtPosId.Margin = new System.Windows.Forms.Padding(6);
+            this.txtPosId.Location = new System.Drawing.Point(6, 38);
             this.txtPosId.MaxLength = 10;
             this.txtPosId.Name = "txtPosId";
-            this.txtPosId.Size = new System.Drawing.Size(496, 37);
+            this.txtPosId.Size = new System.Drawing.Size(250, 22);
             this.txtPosId.TabIndex = 2;
             // 
             // txtSerialNumber
             // 
             this.txtSerialNumber.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtSerialNumber.Location = new System.Drawing.Point(12, 163);
-            this.txtSerialNumber.Margin = new System.Windows.Forms.Padding(6);
+            this.txtSerialNumber.Location = new System.Drawing.Point(6, 85);
             this.txtSerialNumber.MaxLength = 20;
             this.txtSerialNumber.Name = "txtSerialNumber";
-            this.txtSerialNumber.Size = new System.Drawing.Size(496, 37);
+            this.txtSerialNumber.Size = new System.Drawing.Size(250, 22);
             this.txtSerialNumber.TabIndex = 3;
             // 
             // lblSerialNumber
             // 
             this.lblSerialNumber.AutoSize = true;
             this.lblSerialNumber.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblSerialNumber.Location = new System.Drawing.Point(12, 121);
-            this.lblSerialNumber.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblSerialNumber.Location = new System.Drawing.Point(6, 63);
             this.lblSerialNumber.Name = "lblSerialNumber";
-            this.lblSerialNumber.Size = new System.Drawing.Size(222, 31);
+            this.lblSerialNumber.Size = new System.Drawing.Size(114, 16);
             this.lblSerialNumber.TabIndex = 4;
             this.lblSerialNumber.Text = "SERIAL NUMBER";
             // 
@@ -116,37 +111,34 @@
             // 
             this.lblEftposAddress.AutoSize = true;
             this.lblEftposAddress.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblEftposAddress.Location = new System.Drawing.Point(12, 210);
-            this.lblEftposAddress.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblEftposAddress.Location = new System.Drawing.Point(6, 109);
             this.lblEftposAddress.Name = "lblEftposAddress";
-            this.lblEftposAddress.Size = new System.Drawing.Size(240, 31);
+            this.lblEftposAddress.Size = new System.Drawing.Size(122, 16);
             this.lblEftposAddress.TabIndex = 5;
             this.lblEftposAddress.Text = "DEVICE ADDRESS";
             // 
-            // chkAutoAddress
+            // cboxAutoAddress
             // 
-            this.chkAutoAddress.AutoSize = true;
-            this.chkAutoAddress.Checked = true;
-            this.chkAutoAddress.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkAutoAddress.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.chkAutoAddress.Location = new System.Drawing.Point(218, 46);
-            this.chkAutoAddress.Margin = new System.Windows.Forms.Padding(6);
-            this.chkAutoAddress.Name = "chkAutoAddress";
-            this.chkAutoAddress.Size = new System.Drawing.Size(97, 34);
-            this.chkAutoAddress.TabIndex = 6;
-            this.chkAutoAddress.Text = "Auto";
-            this.chkAutoAddress.UseVisualStyleBackColor = true;
-            this.chkAutoAddress.CheckedChanged += new System.EventHandler(this.chkAutoIpAddress_CheckedChanged);
+            this.cboxAutoAddress.AutoSize = true;
+            this.cboxAutoAddress.Checked = true;
+            this.cboxAutoAddress.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cboxAutoAddress.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cboxAutoAddress.Location = new System.Drawing.Point(109, 24);
+            this.cboxAutoAddress.Name = "cboxAutoAddress";
+            this.cboxAutoAddress.Size = new System.Drawing.Size(54, 20);
+            this.cboxAutoAddress.TabIndex = 6;
+            this.cboxAutoAddress.Text = "Auto";
+            this.cboxAutoAddress.UseVisualStyleBackColor = true;
+            this.cboxAutoAddress.CheckedChanged += new System.EventHandler(this.cboxAutoIpAddress_CheckedChanged);
             // 
             // txtAddress
             // 
             this.txtAddress.BackColor = System.Drawing.SystemColors.Window;
             this.txtAddress.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtAddress.Location = new System.Drawing.Point(12, 252);
-            this.txtAddress.Margin = new System.Windows.Forms.Padding(6);
+            this.txtAddress.Location = new System.Drawing.Point(6, 131);
             this.txtAddress.MaxLength = 20;
             this.txtAddress.Name = "txtAddress";
-            this.txtAddress.Size = new System.Drawing.Size(496, 37);
+            this.txtAddress.Size = new System.Drawing.Size(250, 22);
             this.txtAddress.TabIndex = 7;
             // 
             // btnMain
@@ -156,10 +148,9 @@
             this.btnMain.FlatAppearance.BorderColor = System.Drawing.Color.PowderBlue;
             this.btnMain.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnMain.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnMain.Location = new System.Drawing.Point(1220, 794);
-            this.btnMain.Margin = new System.Windows.Forms.Padding(6);
+            this.btnMain.Location = new System.Drawing.Point(610, 413);
             this.btnMain.Name = "btnMain";
-            this.btnMain.Size = new System.Drawing.Size(216, 81);
+            this.btnMain.Size = new System.Drawing.Size(108, 42);
             this.btnMain.TabIndex = 8;
             this.btnMain.Text = "btnMain";
             this.btnMain.UseVisualStyleBackColor = false;
@@ -170,10 +161,9 @@
             this.lblDescription.AutoSize = true;
             this.lblDescription.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblDescription.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.lblDescription.Location = new System.Drawing.Point(54, 63);
-            this.lblDescription.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblDescription.Location = new System.Drawing.Point(27, 33);
             this.lblDescription.Name = "lblDescription";
-            this.lblDescription.Size = new System.Drawing.Size(803, 30);
+            this.lblDescription.Size = new System.Drawing.Size(416, 16);
             this.lblDescription.TabIndex = 9;
             this.lblDescription.Text = "To begin, press PAIR on your terminal and then the PAIR button below";
             // 
@@ -187,10 +177,9 @@
             // 
             this.btnSave.BackColor = System.Drawing.SystemColors.ButtonHighlight;
             this.btnSave.Font = new System.Drawing.Font("Arial", 8F);
-            this.btnSave.Location = new System.Drawing.Point(360, 37);
-            this.btnSave.Margin = new System.Windows.Forms.Padding(6);
+            this.btnSave.Location = new System.Drawing.Point(180, 19);
             this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(128, 60);
+            this.btnSave.Size = new System.Drawing.Size(64, 31);
             this.btnSave.TabIndex = 10;
             this.btnSave.Text = "Save";
             this.btnSave.UseVisualStyleBackColor = false;
@@ -199,13 +188,11 @@
             // grpAutoAddressResolution
             // 
             this.grpAutoAddressResolution.Controls.Add(this.chkTestMode);
-            this.grpAutoAddressResolution.Controls.Add(this.chkAutoAddress);
+            this.grpAutoAddressResolution.Controls.Add(this.cboxAutoAddress);
             this.grpAutoAddressResolution.Controls.Add(this.btnSave);
-            this.grpAutoAddressResolution.Location = new System.Drawing.Point(920, 390);
-            this.grpAutoAddressResolution.Margin = new System.Windows.Forms.Padding(6);
+            this.grpAutoAddressResolution.Location = new System.Drawing.Point(460, 203);
             this.grpAutoAddressResolution.Name = "grpAutoAddressResolution";
-            this.grpAutoAddressResolution.Padding = new System.Windows.Forms.Padding(6);
-            this.grpAutoAddressResolution.Size = new System.Drawing.Size(548, 125);
+            this.grpAutoAddressResolution.Size = new System.Drawing.Size(274, 65);
             this.grpAutoAddressResolution.TabIndex = 11;
             this.grpAutoAddressResolution.TabStop = false;
             this.grpAutoAddressResolution.Text = "Auto Address Resolution";
@@ -216,10 +203,9 @@
             this.chkTestMode.Checked = true;
             this.chkTestMode.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkTestMode.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.chkTestMode.Location = new System.Drawing.Point(12, 46);
-            this.chkTestMode.Margin = new System.Windows.Forms.Padding(6);
+            this.chkTestMode.Location = new System.Drawing.Point(6, 24);
             this.chkTestMode.Name = "chkTestMode";
-            this.chkTestMode.Size = new System.Drawing.Size(163, 34);
+            this.chkTestMode.Size = new System.Drawing.Size(87, 20);
             this.chkTestMode.TabIndex = 12;
             this.chkTestMode.Text = "Test Mode";
             this.chkTestMode.UseVisualStyleBackColor = true;
@@ -228,10 +214,9 @@
             // 
             this.lblPairingStatus.AutoSize = true;
             this.lblPairingStatus.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblPairingStatus.Location = new System.Drawing.Point(924, 819);
-            this.lblPairingStatus.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblPairingStatus.Location = new System.Drawing.Point(462, 426);
             this.lblPairingStatus.Name = "lblPairingStatus";
-            this.lblPairingStatus.Size = new System.Drawing.Size(117, 30);
+            this.lblPairingStatus.Size = new System.Drawing.Size(59, 16);
             this.lblPairingStatus.TabIndex = 12;
             this.lblPairingStatus.Text = "Unpaired";
             // 
@@ -240,10 +225,9 @@
             this.txtSecrets.BackColor = System.Drawing.SystemColors.Window;
             this.txtSecrets.Enabled = false;
             this.txtSecrets.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtSecrets.Location = new System.Drawing.Point(12, 87);
-            this.txtSecrets.Margin = new System.Windows.Forms.Padding(6);
+            this.txtSecrets.Location = new System.Drawing.Point(6, 45);
             this.txtSecrets.Name = "txtSecrets";
-            this.txtSecrets.Size = new System.Drawing.Size(496, 37);
+            this.txtSecrets.Size = new System.Drawing.Size(250, 22);
             this.txtSecrets.TabIndex = 14;
             // 
             // menuStrip1
@@ -253,8 +237,7 @@
             this.transactionsToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Padding = new System.Windows.Forms.Padding(12, 4, 0, 4);
-            this.menuStrip1.Size = new System.Drawing.Size(1476, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(738, 24);
             this.menuStrip1.TabIndex = 15;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -263,7 +246,7 @@
             this.transactionsToolStripMenuItem.BackColor = System.Drawing.Color.LightGray;
             this.transactionsToolStripMenuItem.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold);
             this.transactionsToolStripMenuItem.Name = "transactionsToolStripMenuItem";
-            this.transactionsToolStripMenuItem.Size = new System.Drawing.Size(218, 49);
+            this.transactionsToolStripMenuItem.Size = new System.Drawing.Size(117, 25);
             this.transactionsToolStripMenuItem.Text = "Transactions";
             this.transactionsToolStripMenuItem.Visible = false;
             this.transactionsToolStripMenuItem.Click += new System.EventHandler(this.transactionsToolStripMenuItem_Click);
@@ -276,11 +259,9 @@
             this.grpSettings.Controls.Add(this.lblSerialNumber);
             this.grpSettings.Controls.Add(this.lblEftposAddress);
             this.grpSettings.Controls.Add(this.txtAddress);
-            this.grpSettings.Location = new System.Drawing.Point(920, 63);
-            this.grpSettings.Margin = new System.Windows.Forms.Padding(6);
+            this.grpSettings.Location = new System.Drawing.Point(460, 33);
             this.grpSettings.Name = "grpSettings";
-            this.grpSettings.Padding = new System.Windows.Forms.Padding(6);
-            this.grpSettings.Size = new System.Drawing.Size(548, 315);
+            this.grpSettings.Size = new System.Drawing.Size(274, 164);
             this.grpSettings.TabIndex = 18;
             this.grpSettings.TabStop = false;
             // 
@@ -288,11 +269,9 @@
             // 
             this.grpSecrets.Controls.Add(this.cboxSecrets);
             this.grpSecrets.Controls.Add(this.txtSecrets);
-            this.grpSecrets.Location = new System.Drawing.Point(920, 527);
-            this.grpSecrets.Margin = new System.Windows.Forms.Padding(6);
+            this.grpSecrets.Location = new System.Drawing.Point(460, 274);
             this.grpSecrets.Name = "grpSecrets";
-            this.grpSecrets.Padding = new System.Windows.Forms.Padding(6);
-            this.grpSecrets.Size = new System.Drawing.Size(548, 160);
+            this.grpSecrets.Size = new System.Drawing.Size(274, 83);
             this.grpSecrets.TabIndex = 19;
             this.grpSecrets.TabStop = false;
             // 
@@ -300,10 +279,9 @@
             // 
             this.cboxSecrets.AutoSize = true;
             this.cboxSecrets.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cboxSecrets.Location = new System.Drawing.Point(12, 37);
-            this.cboxSecrets.Margin = new System.Windows.Forms.Padding(6);
+            this.cboxSecrets.Location = new System.Drawing.Point(6, 19);
             this.cboxSecrets.Name = "cboxSecrets";
-            this.cboxSecrets.Size = new System.Drawing.Size(132, 34);
+            this.cboxSecrets.Size = new System.Drawing.Size(72, 20);
             this.cboxSecrets.TabIndex = 15;
             this.cboxSecrets.Text = "Secrets";
             this.cboxSecrets.UseVisualStyleBackColor = true;
@@ -311,10 +289,10 @@
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(1476, 898);
+            this.ClientSize = new System.Drawing.Size(738, 467);
             this.Controls.Add(this.grpSecrets);
             this.Controls.Add(this.grpSettings);
             this.Controls.Add(this.lblPairingStatus);
@@ -326,7 +304,6 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(6);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "MainForm";
@@ -356,7 +333,7 @@
         internal System.Windows.Forms.TextBox txtSerialNumber;
         internal System.Windows.Forms.Label lblSerialNumber;
         internal System.Windows.Forms.Label lblEftposAddress;
-        internal System.Windows.Forms.CheckBox chkAutoAddress;
+        internal System.Windows.Forms.CheckBox cboxAutoAddress;
         internal System.Windows.Forms.TextBox txtAddress;
         internal System.Windows.Forms.Button btnMain;
         internal System.Windows.Forms.Label lblDescription;

--- a/RamenPos/MainForm.cs
+++ b/RamenPos/MainForm.cs
@@ -14,8 +14,6 @@ namespace RamenPos
         private const string AcquirerCode = "wbc";
         public bool IsStarted;
         private Dictionary<string, string> secretsDict = new Dictionary<string, string>();
-        private string validDeviceAddress = "";
-        private string validSerialNumber = "";
 
         public MainForm()
         {
@@ -304,8 +302,6 @@ namespace RamenPos
                         case ResponseCode.SUCCESS:
                             txtAddress.Text = e.Address;
                             btnMain.Enabled = true;
-                            validDeviceAddress = txtAddress.Text;
-                            validSerialNumber = txtSerialNumber.Text;
                             MessageBox.Show($@"Device Address has been updated to {e.Address}", @"Device Address Updated");
                             break;
                         case ResponseCode.ERROR:

--- a/RamenPos/MainForm.cs
+++ b/RamenPos/MainForm.cs
@@ -588,8 +588,16 @@ namespace RamenPos
                             }
                             else if (!SpiClient.CurrentTxFlowState.Finished)
                             {
-                                ActionsForm.btnAction1.Visible = true;
-                                ActionsForm.btnAction1.Text = ButtonCaption.Cancel;
+                                if (SpiClient.CurrentTxFlowState.Type != TransactionType.SettlementEnquiry)
+                                {
+                                    ActionsForm.btnAction1.Visible = true;
+                                    ActionsForm.btnAction1.Text = ButtonCaption.Cancel;
+                                }
+                                else
+                                {
+                                    ActionsForm.btnAction1.Visible = false;
+                                }
+
                                 ActionsForm.btnAction2.Visible = false;
                                 ActionsForm.btnAction3.Visible = false;
                                 GetUnvisibleActionComponents();
@@ -603,11 +611,20 @@ namespace RamenPos
                                         break;
 
                                     case SPIClient.Message.SuccessState.Failed:
+                                        if (SpiClient.CurrentTxFlowState.Type != TransactionType.SettlementEnquiry)
+                                        {
+                                            ActionsForm.btnAction1.Text = ButtonCaption.Retry;
+                                            ActionsForm.btnAction2.Visible = true;
+                                            ActionsForm.btnAction2.Text = ButtonCaption.Cancel;
+                                        }
+                                        else
+                                        {
+                                            ActionsForm.btnAction1.Text = ButtonCaption.OK;
+                                            ActionsForm.btnAction2.Visible = false;
+                                        }
+
                                         ActionsForm.btnAction1.Enabled = true;
                                         ActionsForm.btnAction1.Visible = true;
-                                        ActionsForm.btnAction1.Text = ButtonCaption.Retry;
-                                        ActionsForm.btnAction2.Visible = true;
-                                        ActionsForm.btnAction2.Text = ButtonCaption.Cancel;
                                         ActionsForm.btnAction3.Visible = false;
                                         GetUnvisibleActionComponents();
                                         break;
@@ -669,8 +686,16 @@ namespace RamenPos
                             }
                             else if (!SpiClient.CurrentTxFlowState.Finished)
                             {
-                                ActionsForm.btnAction1.Visible = true;
-                                ActionsForm.btnAction1.Text = ButtonCaption.Cancel;
+                                if (SpiClient.CurrentTxFlowState.Type != TransactionType.SettlementEnquiry)
+                                {
+                                    ActionsForm.btnAction1.Visible = true;
+                                    ActionsForm.btnAction1.Text = ButtonCaption.Cancel;
+                                }
+                                else
+                                {
+                                    ActionsForm.btnAction1.Visible = false;
+                                }
+
                                 ActionsForm.btnAction2.Visible = false;
                                 ActionsForm.btnAction3.Visible = false;
                                 GetUnvisibleActionComponents();
@@ -684,11 +709,20 @@ namespace RamenPos
                                         break;
 
                                     case SPIClient.Message.SuccessState.Failed:
+                                        if (SpiClient.CurrentTxFlowState.Type != TransactionType.SettlementEnquiry)
+                                        {
+                                            ActionsForm.btnAction1.Text = ButtonCaption.Retry;
+                                            ActionsForm.btnAction2.Visible = true;
+                                            ActionsForm.btnAction2.Text = ButtonCaption.Cancel;
+                                        }
+                                        else
+                                        {
+                                            ActionsForm.btnAction1.Text = ButtonCaption.OK;
+                                            ActionsForm.btnAction2.Visible = false;
+                                        }
+
                                         ActionsForm.btnAction1.Enabled = true;
                                         ActionsForm.btnAction1.Visible = true;
-                                        ActionsForm.btnAction1.Text = ButtonCaption.Retry;
-                                        ActionsForm.btnAction2.Visible = true;
-                                        ActionsForm.btnAction2.Text = ButtonCaption.Cancel;
                                         ActionsForm.btnAction3.Visible = false;
                                         GetUnvisibleActionComponents();
                                         break;

--- a/RamenPos/MainForm.cs
+++ b/RamenPos/MainForm.cs
@@ -1,7 +1,9 @@
 ﻿using SPIClient;
 using SPIClient.Service;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 
 namespace RamenPos
@@ -10,6 +12,10 @@ namespace RamenPos
     {
         private const string ApiKey = "RamenPosDeviceAddressApiKey"; // this key needs to be requested from Assembly Payments
         private const string AcquirerCode = "wbc";
+        public bool IsStarted;
+        private Dictionary<string, string> secretsDict = new Dictionary<string, string>();
+        private string validDeviceAddress = "";
+        private string validSerialNumber = "";
 
         public MainForm()
         {
@@ -21,11 +27,26 @@ namespace RamenPos
         private void RamenPos_Load(object sender, EventArgs e)
         {
             MainForm = this;
-            btnMain.Text = ButtonCaption.Pair;
-            txtAddress.Enabled = false;
             TransactionForm = new TransactionForm();
             ActionsForm = new ActionsForm();
+            btnMain.Text = ButtonCaption.Pair;
+            txtAddress.Enabled = false;
 
+            if (File.Exists("Secrets.bin"))
+            {
+                secretsDict = ReadFromBinaryFile<Dictionary<string, string>>("Secrets.bin");
+
+                if (secretsDict.Count > 0)
+                {
+                    txtAddress.Text = secretsDict["EftposAddress"];
+                    txtPosId.Text = secretsDict["PosId"];
+                    txtSecrets.Text = secretsDict["Secrets"];
+                    cboxSecrets.Checked = true;
+                    cboxAutoAddress.Checked = false;
+                }
+            }
+
+            IsStarted = true;
             Start();
         }
 
@@ -38,24 +59,24 @@ namespace RamenPos
                 return;
 
             SpiClient.SetTestMode(chkTestMode.Checked);
-            SpiClient.SetAutoAddressResolution(AutoAddressEnabled); // trigger auto address 
-            SpiClient.SetSerialNumber(SerialNumber); // trigger auto address            
+            SpiClient.SetAutoAddressResolution(AutoAddressEnabled); // trigger auto address             
+            SpiClient.SetSerialNumber(SerialNumber); // trigger auto address
         }
 
-        private void chkAutoIpAddress_CheckedChanged(object sender, EventArgs e)
+        private void cboxAutoIpAddress_CheckedChanged(object sender, EventArgs e)
         {
-            btnMain.Enabled = !chkAutoAddress.Checked;
-            btnSave.Enabled = chkAutoAddress.Checked;
-            chkTestMode.Checked = chkAutoAddress.Checked;
-            chkTestMode.Enabled = chkAutoAddress.Checked;
-            txtAddress.Enabled = !chkAutoAddress.Checked;
+            btnMain.Enabled = true;
+            btnSave.Enabled = cboxAutoAddress.Checked;
+            chkTestMode.Checked = cboxAutoAddress.Checked;
+            chkTestMode.Enabled = cboxAutoAddress.Checked;
+            txtAddress.Enabled = !cboxAutoAddress.Checked;
         }
 
         private bool AreControlsValid(bool isPairing)
         {
             var valid = true;
 
-            AutoAddressEnabled = chkAutoAddress.Checked;
+            AutoAddressEnabled = cboxAutoAddress.Checked;
             PosId = txtPosId.Text;
             EftposAddress = txtAddress.Text;
             SerialNumber = txtSerialNumber.Text;
@@ -74,7 +95,7 @@ namespace RamenPos
                 valid = false;
             }
 
-            if (chkAutoAddress.Checked && string.IsNullOrWhiteSpace(SerialNumber))
+            if (cboxAutoAddress.Checked && string.IsNullOrWhiteSpace(SerialNumber))
             {
                 errorProvider.SetError(txtSerialNumber, "Please provide a Serial Number");
                 valid = false;
@@ -151,6 +172,7 @@ namespace RamenPos
                     if (!AreControlsValidForSecrets())
                         return;
 
+                    IsStarted = false;
                     Secrets = new Secrets(txtSecrets.Text.Split(':')[0], txtSecrets.Text.Split(':')[1]);
                     Start();
                     break;
@@ -159,7 +181,6 @@ namespace RamenPos
                         return;
 
                     SpiClient.SetPosId(PosId);
-                    SpiClient.SetSerialNumber(SerialNumber);
                     SpiClient.SetEftposAddress(EftposAddress);
                     SpiClient.Pair();
                     MainForm.Enabled = false;
@@ -172,18 +193,69 @@ namespace RamenPos
             }
         }
 
+        private static T ReadFromBinaryFile<T>(string filePath)
+        {
+            using (Stream stream = File.Open(filePath, FileMode.Open))
+            {
+                var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                return (T)binaryFormatter.Deserialize(stream);
+            }
+        }
+
+        private static void WriteToBinaryFile<T>(string filePath, T objectToWrite, bool append = false)
+        {
+            using (Stream stream = File.Open(filePath, append ? FileMode.Append : FileMode.Create))
+            {
+                var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                binaryFormatter.Serialize(stream, objectToWrite);
+            }
+        }
+
+        public void SaveSecrets()
+        {
+            if (File.Exists("Secrets.bin"))
+            {
+                if (secretsDict.ContainsKey("PosId"))
+                {
+                    secretsDict["PosId"] = PosId;
+                }
+                else
+                {
+                    secretsDict.Add("PosId", PosId);
+                }
+
+                if (secretsDict.ContainsKey("EftposAddress"))
+                {
+                    secretsDict["EftposAddress"] = EftposAddress;
+                }
+                else
+                {
+                    secretsDict.Add("EftposAddress", EftposAddress);
+                }
+
+                if (secretsDict.ContainsKey("Secrets"))
+                {
+                    secretsDict["Secrets"] = Secrets.EncKey + ":" + Secrets.HmacKey;
+                }
+                else
+                {
+                    secretsDict.Add("Secrets", Secrets.EncKey + ":" + Secrets.HmacKey);
+                }
+
+                File.Delete("Secrets.bin");
+            }
+
+            WriteToBinaryFile("Secrets.bin", secretsDict, false);
+        }
+
         #endregion
 
         #region SPI Client
         private void Start()
         {
             SpiClient = new Spi(PosId, SerialNumber, EftposAddress, Secrets);
-            SpiClient.SetPosInfo("assembly", "2.4.0");
+            SpiClient.SetPosInfo("assembly", "2.6.0");
             Options = new TransactionOptions();
-            Options.SetCustomerReceiptFooter("");
-            Options.SetCustomerReceiptHeader("");
-            Options.SetMerchantReceiptFooter("");
-            Options.SetMerchantReceiptHeader("");
 
             SpiClient.DeviceAddressChanged += OnDeviceAddressChanged;
             SpiClient.StatusChanged += OnSpiStatusChanged;
@@ -210,6 +282,14 @@ namespace RamenPos
     MessageBoxButtons.OK);
                 grpAutoAddressResolution.Enabled = false;
             }
+
+            if (!IsStarted)
+            {
+                this.Invoke(new MethodInvoker(delegate ()
+                {
+                    SpiStatusAndActions();
+                }));
+            }
         }
 
         private void OnDeviceAddressChanged(object sender, DeviceAddressStatus e)
@@ -217,11 +297,33 @@ namespace RamenPos
             this.Invoke(new MethodInvoker(delegate ()
             {
                 btnMain.Enabled = false;
-                if (!string.IsNullOrWhiteSpace(e?.Address))
+                if (e != null)
                 {
-                    txtAddress.Text = e.Address;
-                    btnMain.Enabled = true;
-                    MessageBox.Show($@"Device Address has been updated to {e.Address}", @"Device Address Updated");
+                    switch (e.ResponseCode)
+                    {
+                        case ResponseCode.SUCCESS:
+                            txtAddress.Text = e.Address;
+                            btnMain.Enabled = true;
+                            validDeviceAddress = txtAddress.Text;
+                            validSerialNumber = txtSerialNumber.Text;
+                            MessageBox.Show($@"Device Address has been updated to {e.Address}", @"Device Address Updated");
+                            break;
+                        case ResponseCode.ERROR:
+                            txtAddress.Text = "";
+                            MessageBox.Show("The serial number is invalid!");
+                            break;
+                        case ResponseCode.ADDRESS_NOT_CHANGED:
+                            btnMain.Enabled = true;
+                            MessageBox.Show("The IP address have not changed!");                            
+                            break;
+                        case ResponseCode.SERIAL_NUMBER_NOT_CHANGED:
+                            btnMain.Enabled = true;
+                            MessageBox.Show("The serial number have not changed!");
+                            break;
+                        default:
+                            MessageBox.Show("The serial number is invalid! or The IP address have not changed!");
+                            break;
+                    }
                 }
             }));
         }
@@ -378,6 +480,11 @@ namespace RamenPos
                             transactionsToolStripMenuItem.Visible = false;
                             GetUnvisibleActionComponents();
                             TransactionForm.lblStatus.BackColor = Color.Red;
+                            if (File.Exists("Secrets.bin"))
+                            {
+                                var secretsFile = new FileInfo("Secrets.bin");
+                                File.Delete(secretsFile.FullName);
+                            }
                             break;
 
                         case SpiFlow.Pairing:
@@ -498,6 +605,7 @@ namespace RamenPos
                     switch (SpiClient.CurrentFlow)
                     {
                         case SpiFlow.Idle:
+                            SaveSecrets();
                             btnMain.Text = ButtonCaption.UnPair;
                             TransactionForm.lblStatus.BackColor = Color.Green;
                             ActionsForm.lblFlowMessage.Text = "# --> SPI Status Changed: " + SpiClient.CurrentStatus;
@@ -900,10 +1008,10 @@ namespace RamenPos
                         var schemes = settleResponse.GetSchemeSettlementEntries();
                         foreach (var s in schemes)
                         {
-                            ActionsForm.listBoxFlow.Items.Add("# " + s);                            
+                            ActionsForm.listBoxFlow.Items.Add("# " + s);
                         }
 
-                        TransactionForm.richtextReceipt.Text = TransactionForm.richtextReceipt.Text + Environment.NewLine + "# Merchant Receipt:";                        
+                        TransactionForm.richtextReceipt.Text = TransactionForm.richtextReceipt.Text + Environment.NewLine + "# Merchant Receipt:";
                         TransactionForm.richtextReceipt.Text = !settleResponse.WasMerchantReceiptPrinted() ? TransactionForm.richtextReceipt.Text + Environment.NewLine + settleResponse.GetReceipt().TrimEnd() : TransactionForm.richtextReceipt.Text + Environment.NewLine + "# PRINTED FROM EFTPOS";
                     }
                     break;

--- a/RamenPos/MainForm.cs
+++ b/RamenPos/MainForm.cs
@@ -330,26 +330,26 @@ namespace RamenPos
                 btnMain.Enabled = false;
                 if (e != null)
                 {
-                    switch (e.ResponseCode)
+                    switch (e.DeviceAddressResponseCode)
                     {
-                        case ResponseCode.SUCCESS:
+                        case DeviceAddressResponseCode.SUCCESS:
                             txtAddress.Text = e.Address;
                             btnMain.Enabled = true;
                             MessageBox.Show($@"Device Address has been updated to {e.Address}", @"DEVICE ADRESS UPDATED");
                             break;
-                        case ResponseCode.INVALID_SERIAL_NUMBER:
+                        case DeviceAddressResponseCode.INVALID_SERIAL_NUMBER:
                             txtAddress.Text = "";
                             MessageBox.Show("The serial number is invalid: " + e.ResponseStatusDescription + " : " + e.ResponseMessage, "DEVICE ADRESS ERROR");
                             break;
-                        case ResponseCode.DEVICE_SERVICE_ERROR:
+                        case DeviceAddressResponseCode.DEVICE_SERVICE_ERROR:
                             txtAddress.Text = "";
                             MessageBox.Show("The device service error: " + e.ResponseStatusDescription + " : " + e.ResponseMessage, "DEVICE ADRESS ERROR");
                             break;
-                        case ResponseCode.ADDRESS_NOT_CHANGED:
+                        case DeviceAddressResponseCode.ADDRESS_NOT_CHANGED:
                             btnMain.Enabled = true;
                             MessageBox.Show("The IP address have not changed!", "DEVICE ADRESS ERROR");
                             break;
-                        case ResponseCode.SERIAL_NUMBER_NOT_CHANGED:
+                        case DeviceAddressResponseCode.SERIAL_NUMBER_NOT_CHANGED:
                             btnMain.Enabled = true;
                             MessageBox.Show("The serial number have not changed!", "DEVICE ADRESS ERROR");
                             break;

--- a/RamenPos/MainForm.cs
+++ b/RamenPos/MainForm.cs
@@ -40,7 +40,14 @@ namespace RamenPos
                     txtPosId.Text = secretsDict["PosId"];
                     txtSecrets.Text = secretsDict["Secrets"];
                     cboxSecrets.Checked = true;
-                    cboxAutoAddress.Checked = false;
+                    txtSerialNumber.Text = secretsDict["SerialNumber"];
+                    SerialNumber = secretsDict["SerialNumber"];
+                    bool.TryParse(secretsDict["AutoAddressEnabled"], out bool autoAddressEnabled);
+                    AutoAddressEnabled = autoAddressEnabled;
+                    cboxAutoAddress.Checked = autoAddressEnabled;
+                    bool.TryParse(secretsDict["TestMode"], out bool testMode);
+                    chkTestMode.Checked = testMode;
+                    btnMain.Enabled = true;
                 }
             }
 
@@ -68,6 +75,7 @@ namespace RamenPos
             chkTestMode.Checked = cboxAutoAddress.Checked;
             chkTestMode.Enabled = cboxAutoAddress.Checked;
             txtAddress.Enabled = !cboxAutoAddress.Checked;
+            txtSerialNumber.Enabled = true;
         }
 
         private bool AreControlsValid(bool isPairing)
@@ -184,6 +192,9 @@ namespace RamenPos
                     MainForm.Enabled = false;
                     break;
                 case ButtonCaption.UnPair:
+                    txtPosId.Text = "";
+                    txtAddress.Text = "";
+                    txtSerialNumber.Text = "";
                     SpiClient.Unpair();
                     break;
                 default:
@@ -211,36 +222,58 @@ namespace RamenPos
 
         public void SaveSecrets()
         {
-            if (File.Exists("Secrets.bin"))
+            if (secretsDict.ContainsKey("PosId"))
             {
-                if (secretsDict.ContainsKey("PosId"))
-                {
-                    secretsDict["PosId"] = PosId;
-                }
-                else
-                {
-                    secretsDict.Add("PosId", PosId);
-                }
+                secretsDict["PosId"] = PosId;
+            }
+            else
+            {
+                secretsDict.Add("PosId", PosId);
+            }
 
-                if (secretsDict.ContainsKey("EftposAddress"))
-                {
-                    secretsDict["EftposAddress"] = EftposAddress;
-                }
-                else
-                {
-                    secretsDict.Add("EftposAddress", EftposAddress);
-                }
+            if (secretsDict.ContainsKey("EftposAddress"))
+            {
+                secretsDict["EftposAddress"] = EftposAddress;
+            }
+            else
+            {
+                secretsDict.Add("EftposAddress", EftposAddress);
+            }
 
-                if (secretsDict.ContainsKey("Secrets"))
-                {
-                    secretsDict["Secrets"] = Secrets.EncKey + ":" + Secrets.HmacKey;
-                }
-                else
-                {
-                    secretsDict.Add("Secrets", Secrets.EncKey + ":" + Secrets.HmacKey);
-                }
+            if (secretsDict.ContainsKey("SerialNumber"))
+            {
+                secretsDict["SerialNumber"] = SerialNumber;
+            }
+            else
+            {
+                secretsDict.Add("SerialNumber", SerialNumber);
+            }
 
-                File.Delete("Secrets.bin");
+            if (secretsDict.ContainsKey("AutoAddressEnabled"))
+            {
+                secretsDict["AutoAddressEnabled"] = AutoAddressEnabled.ToString();
+            }
+            else
+            {
+                secretsDict.Add("AutoAddressEnabled", AutoAddressEnabled.ToString());
+            }
+
+            if (secretsDict.ContainsKey("TestMode"))
+            {
+                secretsDict["TestMode"] = chkTestMode.Checked.ToString();
+            }
+            else
+            {
+                secretsDict.Add("TestMode", chkTestMode.Checked.ToString());
+            }
+
+            if (secretsDict.ContainsKey("Secrets"))
+            {
+                secretsDict["Secrets"] = Secrets.EncKey + ":" + Secrets.HmacKey;
+            }
+            else
+            {
+                secretsDict.Add("Secrets", Secrets.EncKey + ":" + Secrets.HmacKey);
             }
 
             WriteToBinaryFile("Secrets.bin", secretsDict, false);

--- a/RamenPos/MainForm.cs
+++ b/RamenPos/MainForm.cs
@@ -302,22 +302,26 @@ namespace RamenPos
                         case ResponseCode.SUCCESS:
                             txtAddress.Text = e.Address;
                             btnMain.Enabled = true;
-                            MessageBox.Show($@"Device Address has been updated to {e.Address}", @"Device Address Updated");
+                            MessageBox.Show($@"Device Address has been updated to {e.Address}", @"DEVICE ADRESS UPDATED");
                             break;
-                        case ResponseCode.ERROR:
+                        case ResponseCode.INVALID_SERIAL_NUMBER:
                             txtAddress.Text = "";
-                            MessageBox.Show("The serial number is invalid!");
+                            MessageBox.Show("The serial number is invalid: " + e.ResponseStatusDescription + " : " + e.ResponseMessage, "DEVICE ADRESS ERROR");
+                            break;
+                        case ResponseCode.DEVICE_SERVICE_ERROR:
+                            txtAddress.Text = "";
+                            MessageBox.Show("The device service error: " + e.ResponseStatusDescription + " : " + e.ResponseMessage, "DEVICE ADRESS ERROR");
                             break;
                         case ResponseCode.ADDRESS_NOT_CHANGED:
                             btnMain.Enabled = true;
-                            MessageBox.Show("The IP address have not changed!");                            
+                            MessageBox.Show("The IP address have not changed!", "DEVICE ADRESS ERROR");
                             break;
                         case ResponseCode.SERIAL_NUMBER_NOT_CHANGED:
                             btnMain.Enabled = true;
-                            MessageBox.Show("The serial number have not changed!");
+                            MessageBox.Show("The serial number have not changed!", "DEVICE ADRESS ERROR");
                             break;
                         default:
-                            MessageBox.Show("The serial number is invalid! or The IP address have not changed!");
+                            MessageBox.Show("The serial number is invalid! or The IP address have not changed!", "DEVICE ADRESS ERROR");
                             break;
                     }
                 }

--- a/RamenPos/Program.cs
+++ b/RamenPos/Program.cs
@@ -16,14 +16,15 @@ namespace RamenPos
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new MainForm());
         }
-    }    
+    }
 
     /// <inheritdoc />
     /// <summary>
     /// Global SpiClient class
     /// </summary>
     public class RamenForm : Form
-    {        internal static Spi SpiClient { get; set; }
+    {
+        internal static Spi SpiClient { get; set; }
         internal static string PosId { get; set; }
         internal static string EftposAddress { get; set; }
         internal static Secrets Secrets { get; set; }

--- a/RamenPos/RamenPos.csproj
+++ b/RamenPos/RamenPos.csproj
@@ -45,7 +45,8 @@
       <HintPath>..\packages\RestSharpSigned.105.2.3\lib\net45\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="SPIClient, Version=2.5.0.136, Culture=neutral, PublicKeyToken=edf39156ce36eff9, processorArchitecture=MSIL">
-      <HintPath>..\packages\SPIClient.2.5.0\lib\net45\SPIClient.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\spi-client-windows\feature-v2.6.0\SPIClient\bin\Debug\SPIClient.dll</HintPath>
     </Reference>
     <Reference Include="SuperSocket.ClientEngine, Version=0.10.0.0, Culture=neutral, PublicKeyToken=ee9af13f57f00acc, processorArchitecture=MSIL">
       <HintPath>..\packages\SuperSocket.ClientEngine.Core.0.10.0\lib\net45\SuperSocket.ClientEngine.dll</HintPath>
@@ -66,7 +67,7 @@
     <Compile Include="ActionsForm.Designer.cs">
       <DependentUpon>ActionsForm.cs</DependentUpon>
     </Compile>
-    <Compile Include="Enums.cs" />
+    <Compile Include="ComponentLabels.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/RamenPos/TransactionForm.cs
+++ b/RamenPos/TransactionForm.cs
@@ -4,8 +4,8 @@ using System.Windows.Forms;
 
 namespace RamenPos
 {
-    public partial class TransactionForm :RamenForm
-    {        
+    public partial class TransactionForm : RamenForm
+    {
         public TransactionForm()
         {
             InitializeComponent();
@@ -83,8 +83,8 @@ namespace RamenPos
 
         private void btnSettle_Click(object sender, EventArgs e)
         {
-            ActionsForm.btnAction1.Visible = true;
-            ActionsForm.btnAction1.Text = ButtonCaption.Cancel;
+            ActionsForm.btnAction1.Enabled = false;
+            ActionsForm.btnAction1.Visible = false;
             ActionsForm.btnAction2.Visible = false;
             ActionsForm.btnAction3.Visible = false;
             ActionsForm.lblAction1.Visible = false;
@@ -133,6 +133,7 @@ namespace RamenPos
             MainForm.grpSecrets.Enabled = false;
             MainForm.grpAutoAddressResolution.Enabled = false;
             MainForm.grpSettings.Enabled = false;
+            MainForm.btnMain.Enabled = true;
             Hide();
             MainForm.Show();
         }
@@ -192,9 +193,8 @@ namespace RamenPos
 
         private void btnSettleEnq_Click(object sender, EventArgs e)
         {
-            ActionsForm.btnAction1.Enabled = true;
-            ActionsForm.btnAction1.Visible = true;
-            ActionsForm.btnAction1.Text = ButtonCaption.Cancel;
+            ActionsForm.btnAction1.Enabled = false;
+            ActionsForm.btnAction1.Visible = false;
             ActionsForm.btnAction2.Visible = false;
             ActionsForm.btnAction3.Visible = false;
             ActionsForm.lblAction1.Visible = false;
@@ -318,10 +318,12 @@ namespace RamenPos
 
             if (Secrets != null)
             {
-                ActionsForm.listBoxFlow.Items.Add("Pos Id: " + PosId);
-                ActionsForm.listBoxFlow.Items.Add("Eftpos Address: " + EftposAddress);
-                ActionsForm.listBoxFlow.Items.Add("Secrets: " + Secrets.EncKey + ":" +
-                  Secrets.HmacKey);
+                ActionsForm.listBoxFlow.Items.Add("Pos Id:");
+                ActionsForm.listBoxFlow.Items.Add(PosId);
+                ActionsForm.listBoxFlow.Items.Add("Eftpos Address:");
+                ActionsForm.listBoxFlow.Items.Add(EftposAddress);
+                ActionsForm.listBoxFlow.Items.Add("Secrets:");
+                ActionsForm.listBoxFlow.Items.Add(Secrets.EncKey + ":" + Secrets.HmacKey);
             }
             else
             {

--- a/RamenPos/TransactionForm.cs
+++ b/RamenPos/TransactionForm.cs
@@ -83,7 +83,6 @@ namespace RamenPos
 
         private void btnSettle_Click(object sender, EventArgs e)
         {
-            ActionsForm.btnAction1.Enabled = false;
             ActionsForm.btnAction1.Visible = false;
             ActionsForm.btnAction2.Visible = false;
             ActionsForm.btnAction3.Visible = false;
@@ -193,7 +192,6 @@ namespace RamenPos
 
         private void btnSettleEnq_Click(object sender, EventArgs e)
         {
-            ActionsForm.btnAction1.Enabled = false;
             ActionsForm.btnAction1.Visible = false;
             ActionsForm.btnAction2.Visible = false;
             ActionsForm.btnAction3.Visible = false;

--- a/TablePos/Program.cs
+++ b/TablePos/Program.cs
@@ -475,17 +475,18 @@ namespace TablePos
             if (_spi.CurrentFlow == SpiFlow.Idle)
             {
                 Console.WriteLine("# ----------- TABLE CONFIG ------------");
-                Console.WriteLine("# [pat_all_enable]       - enable all pay at table settings");
-                Console.WriteLine("# [pat_enabled:true/false]           - enable/disable pay at table");
-                Console.WriteLine("# [operatorid_enabled:true/false]    - enable/disable operator id property");
-                Console.WriteLine("# [set_allowed_operatorid:2]         - set allowed operator id");
-                Console.WriteLine("# [equal_split:true/false]           - enable/disable equal split property");
-                Console.WriteLine("# [split_by_amount:true/false]       - enable/disable split by amount property");
-                Console.WriteLine("# [tipping:true/false]               - enable/disable tipping property");
-                Console.WriteLine("# [summary_report:true/false]        - enable/disable operator id");
-                Console.WriteLine("# [set_label_operatorid:Operator Id] - set operatorid label");
-                Console.WriteLine("# [set_label_tableid:Table Number]   - set tableid label");
-                Console.WriteLine("# [set_label_paybutton:Pay At Table] - set pay button label");
+                Console.WriteLine("# [pat_all_enable]                     - enable all pay at table settings");
+                Console.WriteLine("# [pat_enabled:true/false]             - enable/disable pay at table");
+                Console.WriteLine("# [operatorid_enabled:true/false]      - enable/disable operator id property");
+                Console.WriteLine("# [set_allowed_operatorid:2]           - set allowed operator id");
+                Console.WriteLine("# [equal_split:true/false]             - enable/disable equal split property");
+                Console.WriteLine("# [split_by_amount:true/false]         - enable/disable split by amount property");
+                Console.WriteLine("# [tipping:true/false]                 - enable/disable tipping property");
+                Console.WriteLine("# [summary_report:true/false]          - enable/disable operator id");
+                Console.WriteLine("# [set_label_operatorid:Operator Id]   - set operatorid label");
+                Console.WriteLine("# [set_label_tableid:Table Number]     - set tableid label");
+                Console.WriteLine("# [set_label_paybutton:Pay At Table]   - set pay button label");
+                Console.WriteLine("# [table_retrieval_enabled:true/false] - enable/disable operator id");
                 Console.WriteLine("# ----------- OTHER ACTIONS ------------");
                 Console.WriteLine("# [purchase:1200] - Quick Purchase Tx");
                 Console.WriteLine("# [yuck] - hand out a refund!");
@@ -745,6 +746,15 @@ namespace TablePos
                     case "set_label_paybutton":
                         if (!CheckInput(spInput, 1)) { break; };
                         _pat.Config.LabelPayButton = spInput[1];
+                        _pat.PushPayAtTableConfig();
+                        Console.Write("> ");
+                        break;
+
+                    case "table_retrieval_enabled":
+                        if (!CheckInput(spInput, 1)) { break; };
+                        output = false;
+                        bool.TryParse(spInput[1], out output);
+                        _pat.Config.TableRetrievalEnabled = output;
                         _pat.PushPayAtTableConfig();
                         Console.Write("> ");
                         break;

--- a/TablePos/Program.cs
+++ b/TablePos/Program.cs
@@ -486,7 +486,7 @@ namespace TablePos
                 Console.WriteLine("# [set_label_operatorid:Operator Id]   - set operatorid label");
                 Console.WriteLine("# [set_label_tableid:Table Number]     - set tableid label");
                 Console.WriteLine("# [set_label_paybutton:Pay At Table]   - set pay button label");
-                Console.WriteLine("# [table_retrieval_enabled:true/false] - enable/disable operator id");
+                Console.WriteLine("# [table_retrieval_enabled:true/false] - enable/disable table retrieval button");
                 Console.WriteLine("# ----------- OTHER ACTIONS ------------");
                 Console.WriteLine("# [purchase:1200] - Quick Purchase Tx");
                 Console.WriteLine("# [yuck] - hand out a refund!");

--- a/TablePos/Program.cs
+++ b/TablePos/Program.cs
@@ -223,6 +223,7 @@ namespace TablePos
             var bill = billsStore[billPayment.BillId];
             bill.OutstandingAmount -= billPayment.PurchaseAmount;
             bill.TippedAmount += billPayment.TipAmount;
+            bill.SurchargeAmount += billPayment.SurchargeAmount;
             bill.Locked = bill.OutstandingAmount == 0 ? false : true;
 
             Console.WriteLine($"Updated Bill: {bill}");
@@ -1040,6 +1041,7 @@ namespace TablePos
             public int TotalAmount = 0;
             public int OutstandingAmount = 0;
             public int TippedAmount = 0;
+            public int SurchargeAmount = 0;
             public bool Locked = false;
 
 
@@ -1047,7 +1049,7 @@ namespace TablePos
             public override string ToString()
             {
                 return $"{BillId} - Table:{TableId} Operator Id:{OperatorId} Label:{Label} Total:${TotalAmount / 100.0:0.00} " +
-                    $"Outstanding:${OutstandingAmount / 100.0:0.00} Tips:${TippedAmount / 100.0:0.00} Locked:{Locked}";
+                    $"Outstanding:${OutstandingAmount / 100.0:0.00} Tips:${TippedAmount / 100.0:0.00} Surcharge:${SurchargeAmount / 100.0:0.00}  Locked:{Locked}";
             }
         }
 

--- a/TablePos/TablePos.csproj
+++ b/TablePos/TablePos.csproj
@@ -41,7 +41,8 @@
       <HintPath>..\packages\RestSharpSigned.105.2.3\lib\net45\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="SPIClient, Version=2.5.0.136, Culture=neutral, PublicKeyToken=edf39156ce36eff9, processorArchitecture=MSIL">
-      <HintPath>..\packages\SPIClient.2.5.0\lib\net45\SPIClient.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\spi-client-windows\feature-v2.6.0\SPIClient\bin\Debug\SPIClient.dll</HintPath>
     </Reference>
     <Reference Include="SuperSocket.ClientEngine, Version=0.10.0.0, Culture=neutral, PublicKeyToken=ee9af13f57f00acc, processorArchitecture=MSIL">
       <HintPath>..\packages\SuperSocket.ClientEngine.Core.0.10.0\lib\net45\SuperSocket.ClientEngine.dll</HintPath>


### PR DESCRIPTION
SP-22 Canceling Settlement Inquiry not sending response back to terminal - Remove cancel button from Samples
SP-24 Display an error message in RamenPOS when attempting to save with an invalid serial number
SP-25 Ability to enable/disable all library configurable from sample POS
SP-26 Auto Address Resolution - No feedback when no IP/FQDN returned
SP-27 Some pay at table configuration settings not taking effect on EFTPOS terminal
SP-28 Surcharge from pay at table transactions not being displayed in TablePOS
SP-34 "table_retrieval_enabled": parameter should NOT be enabled by default
SP-36 Ramenpos does not remember pairing status after restart